### PR TITLE
fix a bug of repetitive reading LengthAdjustment

### DIFF
--- a/length_field_based_frameconn.go
+++ b/length_field_based_frameconn.go
@@ -69,13 +69,6 @@ func (fc *lengthFieldBasedFrameConn) ReadFrame() ([]byte, error) {
 		return nil, err
 	}
 
-	if fc.decoderConfig.LengthAdjustment > 0 { //discard adjust header
-		_, err := ReadN(fc.c, fc.decoderConfig.LengthAdjustment)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// real message length
 	msgLength := int(frameLength) + fc.decoderConfig.LengthAdjustment
 	msg, err := ReadN(fc.r, msgLength)


### PR DESCRIPTION
https://github.com/smallnest/goframe/blob/1fbd8e51db1864af319efd9be934e24efe682ed7/length_field_based_frameconn.go#L72-L81
当 `LengthAdjustment` > 0 时，会重复读取了两次 `LengthAdjustment` 长度的数据，导致解码异常，像是下面这种设置：
```
 lengthFieldOffset   = 1 (= the length of HDR1)
 lengthFieldLength   = 2
 lengthAdjustment    = 1 (= the length of HDR2)
 initialBytesToStrip = 3 (= the length of HDR1 + LEN)

 BEFORE DECODE (16 bytes)                       AFTER DECODE (13 bytes)
 +------+--------+------+----------------+      +------+----------------+
 | HDR1 | Length | HDR2 | Actual Content |----->| HDR2 | Actual Content |
 | 0xCA | 0x000C | 0xFE | "HELLO, WORLD" |      | 0xFE | "HELLO, WORLD" |
 +------+--------+------+----------------+      +------+----------------+
```
现在的代码会导致多读取 "Actual Content" 后面的一个 byte。