### PR TITLE
Fix deadlock with RWMutex in LengthFieldBasedFrameConn

### DIFF
--- a/length_field_based_frameconn.go
+++ b/length_field_based_frameconn.go
@@ -92,9 +92,6 @@ func (fc *lengthFieldBasedFrameConn) ReadFrame() ([]byte, error) {
 }
 
 func (fc *lengthFieldBasedFrameConn) getUnadjustedFrameLength() (lenBuf []byte, n uint64, err error) {
-	fc.m.RLock()
-	defer fc.m.RUnlock()
-
 	switch fc.decoderConfig.LengthFieldLength {
 	case 1:
 		b, err := fc.r.ReadByte()

--- a/length_field_based_frameconn.go
+++ b/length_field_based_frameconn.go
@@ -14,7 +14,8 @@ type lengthFieldBasedFrameConn struct {
 	c             net.Conn
 	r             *bufio.Reader
 	w             *bufio.Writer
-	m             sync.RWMutex
+	rm            sync.Mutex
+	wm            sync.Mutex
 }
 
 // EncoderConfig config for encoder.
@@ -53,7 +54,8 @@ func NewLengthFieldBasedFrameConn(encoderConfig EncoderConfig, decoderConfig Dec
 		c:             conn,
 		r:             bufio.NewReader(conn),
 		w:             bufio.NewWriter(conn),
-		m:             sync.RWMutex{},
+		rm:            sync.Mutex{},
+		wm:            sync.Mutex{},
 	}
 }
 
@@ -61,8 +63,8 @@ func (fc *lengthFieldBasedFrameConn) ReadFrame() ([]byte, error) {
 	var header []byte
 	var err error
 
-	fc.m.RLock()
-	defer fc.m.RUnlock()
+	fc.rm.Lock()
+	defer fc.rm.Unlock()
 
 	if fc.decoderConfig.LengthFieldOffset > 0 { //discard header(offset)
 		header, err = ReadN(fc.r, fc.decoderConfig.LengthFieldOffset)
@@ -145,8 +147,8 @@ func (fc *lengthFieldBasedFrameConn) WriteFrame(p []byte) error {
 	}
 
 	var err error
-	fc.m.Lock()
-	defer fc.m.Unlock()
+	fc.wm.Lock()
+	defer fc.wm.Unlock()
 
 	switch fc.encoderConfig.LengthFieldLength {
 	case 1:


### PR DESCRIPTION
* Switched out RWMutex to use two separate Mutex objects, one for read and one for write - as there are two separate buffers it doesn't make sense to use a single RWMutex which will cause unnecessary blocking (which we have seen in testing)
* Fixed superfluous call to lock the read mutex in the `getUnadjustedFrameLength` function - there was already a Read lock acquired, so this was causing a deadlock.

Sorry I didn't pick on on this in the last PR, I have tested this extensively in our implementation and I am happy this is now working properly based on these changes.